### PR TITLE
Funcionalidad y logica del backend para el atributo de urgencia en los posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ package-lock.json
 *.mongodb
 link-plugins.sh
 test.sh
+dump.rdb
 
 .docker/**
 !**/.gitkeep

--- a/install/data/urgencies.json
+++ b/install/data/urgencies.json
@@ -1,0 +1,38 @@
+[
+    {
+        "name": "High Priority",
+        "description": "High priority issues that need immediate attention",
+        "descriptionParsed": "<p>High priority issues that need immediate attention</p>\n",
+        "bgColor": "#e95c5a",
+        "color": "#ffffff",
+        "icon" : "fa-exclamation-triangle",
+        "order": 1
+    },
+    {
+        "name": "Medium Priority",
+        "description": "Medium priority issues that need attention",
+        "descriptionParsed": "<p>Medium priority issues that need attention</p>\n",
+        "bgColor": "#fda34b",
+        "color": "#ffffff",
+        "icon" : "fa-exclamation-circle",
+        "order": 2
+    },
+    {
+        "name": "Low Priority",
+        "description": "Low priority issues that need attention",
+        "descriptionParsed": "<p>Low priority issues that need attention</p>\n",
+        "bgColor": "#59b3d0",
+        "color": "#ffffff",
+        "icon" : "fa-exclamation",
+        "order": 3
+    },
+    {
+        "name": "No Priority",
+        "description": "Issues that need attention but are not urgent",
+        "descriptionParsed": "<p>Issues that need attention but are not urgent</p>\n",
+        "bgColor": "#86ba4b",
+        "color": "#ffffff",
+        "icon" : "fa-exclamation-circle",
+        "order": 0
+    }
+]

--- a/install/data/urgencies.json
+++ b/install/data/urgencies.json
@@ -1,12 +1,21 @@
 [
     {
+        "name": "No Priority",
+        "description": "Issues that need attention but are not urgent",
+        "descriptionParsed": "<p>Issues that need attention but are not urgent</p>\n",
+        "bgColor": "#86ba4b",
+        "color": "#ffffff",
+        "icon" : "fa-exclamation-circle",
+        "order": 1
+    },
+    {
         "name": "High Priority",
         "description": "High priority issues that need immediate attention",
         "descriptionParsed": "<p>High priority issues that need immediate attention</p>\n",
         "bgColor": "#e95c5a",
         "color": "#ffffff",
         "icon" : "fa-exclamation-triangle",
-        "order": 1
+        "order": 2
     },
     {
         "name": "Medium Priority",
@@ -15,7 +24,7 @@
         "bgColor": "#fda34b",
         "color": "#ffffff",
         "icon" : "fa-exclamation-circle",
-        "order": 2
+        "order": 3
     },
     {
         "name": "Low Priority",
@@ -24,15 +33,6 @@
         "bgColor": "#59b3d0",
         "color": "#ffffff",
         "icon" : "fa-exclamation",
-        "order": 3
-    },
-    {
-        "name": "No Priority",
-        "description": "Issues that need attention but are not urgent",
-        "descriptionParsed": "<p>Issues that need attention but are not urgent</p>\n",
-        "bgColor": "#86ba4b",
-        "color": "#ffffff",
-        "icon" : "fa-exclamation-circle",
-        "order": 0
+        "order": 4
     }
 ]

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -122,6 +122,7 @@ postsAPI.edit = async function (caller, data) {
 			pid: editResult.post.pid,
 			oldContent: editResult.post.oldContent,
 			newContent: editResult.post.newContent,
+			urg_id: data.urg_id,
 		});
 	}
 
@@ -394,13 +395,13 @@ async function canSeeVotes(uid, cids, type) {
 	const cidToAllowed = _.zipObject(uniqCids, canRead);
 	const checks = cids.map(
 		(cid, index) => isAdmin || isMod[index] ||
-		(
-			cidToAllowed[cid] &&
 			(
-				meta.config[type] === 'all' ||
-				(meta.config[type] === 'loggedin' && parseInt(uid, 10) > 0)
+				cidToAllowed[cid] &&
+				(
+					meta.config[type] === 'all' ||
+					(meta.config[type] === 'loggedin' && parseInt(uid, 10) > 0)
+				)
 			)
-		)
 	);
 	return isArray ? checks : checks[0];
 }

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -37,6 +37,8 @@ Controllers.osd = require('./osd');
 Controllers['404'] = require('./404');
 Controllers.errors = require('./errors');
 Controllers.composer = require('./composer');
+Controllers.urgency = require('./urgency');
+Controllers.urgencies = require('./urgencies');
 
 Controllers.write = require('./write');
 

--- a/src/controllers/urgencies.js
+++ b/src/controllers/urgencies.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const urgencies = require('../urgencies');
+
+const categoriesController = module.exports;
+
+categoriesController.list = async function (req, res) {
+	const data = await urgencies.getAllUrgencies();
+
+	res.render('urgencies', data);
+};

--- a/src/controllers/urgency.js
+++ b/src/controllers/urgency.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const urgencies = require('../urgencies');
+
+const urgencyController = module.exports;
+
+urgencyController.get = async function (req, res, next) {
+	const { urg_id } = req.params;
+
+	const categoryData = await urgencies.getUrgencyById({
+		urg_id: urg_id,
+		uid: req.uid,
+	});
+	if (!categoryData) {
+		return next();
+	}
+
+	res.render('category', categoryData);
+};

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -179,3 +179,8 @@ Posts.getReplies = async (req, res) => {
 
 	helpers.formatApiResponse(200, res, { replies });
 };
+
+Posts.getUrgentPosts = async (req, res) => {
+	const urgentPosts = await posts.getUrgentPosts(req.uid);
+	helpers.formatApiResponse(200, res, urgentPosts);
+};

--- a/src/install.js
+++ b/src/install.js
@@ -458,6 +458,27 @@ async function createCategories() {
 	}
 }
 
+async function createUgrencies() {
+	const Urgencies = require('./urgencies');
+	const db = require('./database');
+	const cids = await db.getSortedSetRange('urgencies:urg_id', 0, -1);
+	if (Array.isArray(cids) && cids.length) {
+		console.log(`Categories OK. Found ${cids.length} categories.`);
+		return;
+	}
+
+	console.log('No urgencies found, populating instance with default urgencies');
+
+	const default_urgencies = JSON.parse(
+		await fs.promises.readFile(path.join(__dirname, '../', 'install/data/urgencies.json'), 'utf8')
+	);
+	for (const categoryData of default_urgencies) {
+		// eslint-disable-next-line no-await-in-loop
+		const p = await Urgencies.create(categoryData);
+		console.log(p);
+	}
+}
+
 async function createMenuItems() {
 	const db = require('./database');
 
@@ -584,6 +605,7 @@ install.setup = async function () {
 		await setupDefaultConfigs();
 		await enableDefaultTheme();
 		await createCategories();
+		await createUgrencies();
 		await createDefaultUserGroups();
 		const adminInfo = await createAdministrator();
 		await createGlobalModeratorsGroup();

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -35,7 +35,10 @@ module.exports = function (Posts) {
 			tid: tid,
 			content: content,
 			timestamp: timestamp,
+			urgency: 0,
 		};
+
+		console.log(postData);
 
 		if (data.toPid) {
 			postData.toPid = data.toPid;
@@ -47,7 +50,10 @@ module.exports = function (Posts) {
 			postData.handle = data.handle;
 		}
 
-		let result = await plugins.hooks.fire('filter:post.create', { post: postData, data: data });
+		let result = await plugins.hooks.fire('filter:post.create', {
+			post: postData,
+			data: data,
+		});
 		postData = result.post;
 		await db.setObject(`post:${postData.pid}`, postData);
 
@@ -65,7 +71,10 @@ module.exports = function (Posts) {
 			Posts.uploads.sync(postData.pid),
 		]);
 
-		result = await plugins.hooks.fire('filter:post.get', { post: postData, uid: data.uid });
+		result = await plugins.hooks.fire('filter:post.get', {
+			post: postData,
+			uid: data.uid,
+		});
 		result.post.isMain = isMain;
 		plugins.hooks.fire('action:post.save', { post: _.clone(result.post) });
 		return result.post;

--- a/src/posts/diffs.js
+++ b/src/posts/diffs.js
@@ -38,11 +38,12 @@ module.exports = function (Posts) {
 	};
 
 	Diffs.save = async function (data) {
-		const { pid, uid, oldContent, newContent, edited, topic } = data;
+		const { pid, uid, oldContent, newContent, edited, topic, urg_id } = data;
 		const editTimestamp = edited || Date.now();
 		const diffData = {
 			uid: uid,
 			pid: pid,
+			urg_id: urg_id,
 		};
 		if (oldContent !== newContent) {
 			diffData.patch = diff.createPatch('', newContent, oldContent);

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -47,6 +47,7 @@ module.exports = function (Posts) {
 			post: editPostData,
 			data: data,
 			uid: data.uid,
+			urg_id: data.urg_id,
 		});
 
 		const [editor, topic] = await Promise.all([

--- a/src/posts/index.js
+++ b/src/posts/index.js
@@ -53,6 +53,14 @@ Posts.getPostsByPids = async function (pids, uid) {
 	return data.posts.filter(Boolean);
 };
 
+Posts.getUrgentPosts = async function (uid) {
+	const pids = await db.getSortedSetRevRange('posts:urgent', 0, 100);
+	const posts = await Posts.getPostsByPids(pids, uid);
+	return posts
+		.filter(post => parseInt(post.urg_id, 10) > 1)
+		.toSorted((a, b) => parseInt(a.urg_id, 10) - parseInt(b.urg_id, 10));
+};
+
 Posts.getPostSummariesFromSet = async function (set, uid, start, stop) {
 	let pids = await db.getSortedSetRevRange(set, start, stop);
 	pids = await privileges.posts.filter('topics:read', pids, uid);

--- a/src/posts/index.js
+++ b/src/posts/index.js
@@ -54,7 +54,7 @@ Posts.getPostsByPids = async function (pids, uid) {
 };
 
 Posts.getUrgentPosts = async function (uid) {
-	const pids = await db.getSortedSetRevRange('posts:urgent', 0, 100);
+	const pids = await db.getSortedSetRevRange('posts:pid', 0, 100);
 	const posts = await Posts.getPostsByPids(pids, uid);
 	return posts
 		.filter(post => parseInt(post.urg_id, 10) > 1)

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -22,6 +22,8 @@ module.exports = function (app, middleware, controllers) {
 	router.get('/unread/total', [...middlewares, middleware.ensureLoggedIn], helpers.tryRoute(controllers.unread.unreadTotal));
 	router.get('/topic/teaser/:topic_id', [...middlewares], helpers.tryRoute(controllers.topics.teaser));
 	router.get('/topic/pagination/:topic_id', [...middlewares], helpers.tryRoute(controllers.topics.pagination));
+	router.get('/urgency', [...middlewares], helpers.tryRoute(controllers.urgencies.list));
+	router.get('/urgency/:urg_id', [...middlewares], helpers.tryRoute(controllers.urgency.get));
 
 	const multipart = require('connect-multiparty');
 	const multipartMiddleware = multipart();

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -15,6 +15,8 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:pid', [middleware.ensureLoggedIn, middleware.checkRequired.bind(null, ['content'])], controllers.write.posts.edit);
 	setupApiRoute(router, 'delete', '/:pid', middlewares, controllers.write.posts.purge);
 
+	setupApiRoute(router, 'get', '/:uid/urgency', [], controllers.write.posts.getUrgentPosts);
+
 	setupApiRoute(router, 'get', '/:pid/index', [middleware.assert.post], controllers.write.posts.getIndex);
 	setupApiRoute(router, 'get', '/:pid/raw', [middleware.assert.post], controllers.write.posts.getRaw);
 	setupApiRoute(router, 'get', '/:pid/summary', [middleware.assert.post], controllers.write.posts.getSummary);

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -122,6 +122,7 @@ module.exports = function (Topics) {
 		let postData = data;
 		postData.tid = tid;
 		postData.ip = data.req ? data.req.ip : null;
+		postData.urg_id = data.urg_id || 1;
 		postData.isMain = true;
 		postData = await posts.create(postData);
 		postData = await onNewPost(postData, data);

--- a/src/urgencies/create.js
+++ b/src/urgencies/create.js
@@ -1,0 +1,154 @@
+'use strict';
+
+const async = require('async');
+
+const db = require('../database');
+const plugins = require('../plugins');
+// const privileges = require('../privileges');
+const utils = require('../utils');
+const slugify = require('../slugify');
+const cache = require('../cache');
+
+module.exports = function (Urgencies) {
+	Urgencies.create = async function (data) {
+		const parentCid = data.parentCid ? data.parentCid : 0;
+		const [urgentId, firstChild] = await Promise.all([
+			db.incrObjectField('global', 'nextUrgId'),
+			db.getSortedSetRangeWithScores(`urg_id:${parentCid}:children`, 0, 0),
+		]);
+
+		data.name = String(data.name || `Urgency ${urgentId}`);
+		const slug = `${urgentId}/${slugify(data.name)}`;
+		const smallestOrder = firstChild.length ? firstChild[0].score - 1 : 1;
+		const order = data.order || smallestOrder; // If no order provided, place it at the top
+		const colours = Urgencies.assignColours();
+
+		let urgencyInfo = {
+			urg_id: urgentId || order,
+			name: data.name,
+			description: data.description ? data.description : '',
+			descriptionParsed: data.descriptionParsed ? data.descriptionParsed : '',
+			icon: data.icon ? data.icon : '',
+			bgColor: data.bgColor || colours[0],
+			color: data.color || colours[1],
+			slug: slug,
+			parentCid: parentCid,
+			topic_count: 0,
+			post_count: 0,
+			disabled: data.disabled ? 1 : 0,
+			order: order,
+			link: data.link || '',
+			numRecentReplies: 1,
+			class: (data.class ? data.class : 'col-md-3 col-6'),
+			imageClass: 'cover',
+			isSection: 0,
+			subCategoriesPerPage: 10,
+		};
+
+		if (data.backgroundImage) {
+			urgencyInfo.backgroundImage = data.backgroundImage;
+		}
+
+		const defaultPrivileges = [
+			'groups:find',
+			'groups:read',
+			'groups:topics:read',
+			'groups:topics:create',
+			'groups:topics:reply',
+			'groups:topics:tag',
+			'groups:posts:edit',
+			'groups:posts:history',
+			'groups:posts:delete',
+			'groups:posts:upvote',
+			'groups:posts:downvote',
+			'groups:topics:delete',
+		];
+		const modPrivileges = defaultPrivileges.concat([
+			'groups:topics:schedule',
+			'groups:posts:view_deleted',
+			'groups:purge',
+		]);
+		const guestPrivileges = ['groups:find', 'groups:read', 'groups:topics:read'];
+
+		const result = await plugins.hooks.fire('filter:urgency.create', {
+			urgency: urgencyInfo,
+			data: data,
+			defaultPrivileges: defaultPrivileges,
+			modPrivileges: modPrivileges,
+			guestPrivileges: guestPrivileges,
+		});
+		urgencyInfo = result.urgency;
+
+		await db.setObject(`urgency:${urgencyInfo.cid}`, urgencyInfo);
+		if (!urgencyInfo.descriptionParsed) {
+			await Urgencies.parseDescription(urgencyInfo.cid, urgencyInfo.description);
+		}
+
+		await db.sortedSetAddBulk([
+			['urgencies:urg_id', urgencyInfo.order, urgencyInfo.cid],
+			[`urg_id:${parentCid}:children`, urgencyInfo.order, urgencyInfo.cid],
+			['urgencies:name', 0, `${data.name.slice(0, 200).toLowerCase()}:${urgencyInfo.cid}`],
+		]);
+
+		// await privileges.categories.give(result.defaultPrivileges, urgencyInfo.cid, 'registered-users');
+		// await privileges.categories.give(result.modPrivileges, urgencyInfo.cid, ['administrators', 'Global Moderators']);
+		// await privileges.categories.give(result.guestPrivileges, urgencyInfo.cid, ['guests', 'spiders']);
+
+		cache.del('urgencies:cid');
+		await clearParentCategoryCache(parentCid);
+
+		if (data.cloneFromCid && parseInt(data.cloneFromCid, 10)) {
+			urgencyInfo = await Urgencies.copySettingsFrom(data.cloneFromCid, urgencyInfo.cid, !data.parentCid);
+		}
+
+		if (data.cloneChildren) {
+			await duplicateCategoriesChildren(urgencyInfo.cid, data.cloneFromCid, data.uid);
+		}
+
+		plugins.hooks.fire('action:urgency.create', { category: urgencyInfo });
+		return urgencyInfo;
+	};
+
+	async function clearParentCategoryCache(parentUrgid) {
+		while (parseInt(parentUrgid, 10) >= 0) {
+			cache.del([
+				`urg_id:${parentUrgid}:children`,
+				`urg_id:${parentUrgid}:children:all`,
+			]);
+
+			if (parseInt(parentUrgid, 10) === 0) {
+				return;
+			}
+			// clear all the way to root
+			// eslint-disable-next-line no-await-in-loop
+			parentUrgid = await Urgencies.getCategoryField(parentUrgid, 'parentUrgid');
+		}
+	}
+
+	async function duplicateCategoriesChildren(parentUrgid, urg_id, uid) {
+		let children = await Urgencies.getChildren([urg_id], uid);
+		if (!children.length) {
+			return;
+		}
+
+		children = children[0];
+
+		children.forEach((child) => {
+			child.parentCid = parentUrgid;
+			child.cloneFromCid = child.cid;
+			child.cloneChildren = true;
+			child.name = utils.decodeHTMLEntities(child.name);
+			child.description = utils.decodeHTMLEntities(child.description);
+			child.uid = uid;
+		});
+
+		await async.each(children, Urgencies.create);
+	}
+
+	Urgencies.assignColours = function () {
+		const backgrounds = ['#AB4642', '#DC9656', '#F7CA88', '#A1B56C', '#86C1B9', '#7CAFC2', '#BA8BAF', '#A16946'];
+		const text = ['#ffffff', '#ffffff', '#333333', '#ffffff', '#333333', '#ffffff', '#ffffff', '#ffffff'];
+		const index = Math.floor(Math.random() * backgrounds.length);
+		return [backgrounds[index], text[index]];
+	};
+};

--- a/src/urgencies/data.js
+++ b/src/urgencies/data.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const validator = require('validator');
+
+const db = require('../database');
+const meta = require('../meta');
+const plugins = require('../plugins');
+const utils = require('../utils');
+
+const intFields = [
+	'cid', 'parentCid', 'disabled', 'isSection', 'order',
+	'topic_count', 'post_count', 'numRecentReplies',
+	'minTags', 'maxTags', 'postQueue', 'subCategoriesPerPage',
+];
+
+module.exports = function (Categories) {
+	Categories.getCategoriesFields = async function (cids, fields) {
+		if (!Array.isArray(cids) || !cids.length) {
+			return [];
+		}
+
+		const keys = cids.map(cid => `category:${cid}`);
+		const categories = await db.getObjects(keys, fields);
+		const result = await plugins.hooks.fire('filter:category.getFields', {
+			cids: cids,
+			categories: categories,
+			fields: fields,
+			keys: keys,
+		});
+		result.categories.forEach(category => modifyCategory(category, fields));
+		return result.categories;
+	};
+
+	Categories.getCategoryData = async function (cid) {
+		const categories = await Categories.getCategoriesFields([cid], []);
+		return categories && categories.length ? categories[0] : null;
+	};
+
+	Categories.getCategoriesData = async function (cids) {
+		return await Categories.getCategoriesFields(cids, []);
+	};
+
+	Categories.getCategoryField = async function (cid, field) {
+		const category = await Categories.getCategoryFields(cid, [field]);
+		return category ? category[field] : null;
+	};
+
+	Categories.getCategoryFields = async function (cid, fields) {
+		const categories = await Categories.getCategoriesFields([cid], fields);
+		return categories ? categories[0] : null;
+	};
+
+	Categories.getAllCategoryFields = async function (fields) {
+		const cids = await Categories.getAllCidsFromSet('categories:cid');
+		return await Categories.getCategoriesFields(cids, fields);
+	};
+
+	Categories.setCategoryField = async function (cid, field, value) {
+		await db.setObjectField(`category:${cid}`, field, value);
+	};
+
+	Categories.incrementCategoryFieldBy = async function (cid, field, value) {
+		await db.incrObjectFieldBy(`category:${cid}`, field, value);
+	};
+};
+
+function defaultIntField(category, fields, fieldName, defaultField) {
+	if (!fields.length || fields.includes(fieldName)) {
+		const useDefault = !category.hasOwnProperty(fieldName) ||
+			category[fieldName] === null ||
+			category[fieldName] === '' ||
+			!utils.isNumber(category[fieldName]);
+
+		category[fieldName] = useDefault ? meta.config[defaultField] : category[fieldName];
+	}
+}
+
+function modifyCategory(category, fields) {
+	if (!category) {
+		return;
+	}
+
+	defaultIntField(category, fields, 'minTags', 'minimumTagsPerTopic');
+	defaultIntField(category, fields, 'maxTags', 'maximumTagsPerTopic');
+	defaultIntField(category, fields, 'postQueue', 'postQueue');
+
+	db.parseIntFields(category, intFields, fields);
+
+	const escapeFields = ['name', 'color', 'bgColor', 'backgroundImage', 'imageClass', 'class', 'link'];
+	escapeFields.forEach((field) => {
+		if (category.hasOwnProperty(field)) {
+			category[field] = validator.escape(String(category[field] || ''));
+		}
+	});
+
+	if (category.hasOwnProperty('icon')) {
+		category.icon = category.icon || 'hidden';
+	}
+
+	if (category.hasOwnProperty('post_count')) {
+		category.totalPostCount = category.post_count;
+	}
+
+	if (category.hasOwnProperty('topic_count')) {
+		category.totalTopicCount = category.topic_count;
+	}
+
+	if (category.description) {
+		category.description = validator.escape(String(category.description));
+		category.descriptionParsed = category.descriptionParsed || category.description;
+	}
+}

--- a/src/urgencies/data.js
+++ b/src/urgencies/data.js
@@ -13,100 +13,100 @@ const intFields = [
 	'minTags', 'maxTags', 'postQueue', 'subCategoriesPerPage',
 ];
 
-module.exports = function (Categories) {
-	Categories.getCategoriesFields = async function (cids, fields) {
-		if (!Array.isArray(cids) || !cids.length) {
+module.exports = function (Urgencies) {
+	Urgencies.getUrgenciesFields = async function (urg_ids, fields) {
+		if (!Array.isArray(urg_ids) || !urg_ids.length) {
 			return [];
 		}
 
-		const keys = cids.map(cid => `category:${cid}`);
-		const categories = await db.getObjects(keys, fields);
-		const result = await plugins.hooks.fire('filter:category.getFields', {
-			cids: cids,
-			categories: categories,
+		const keys = urg_ids.map(urg_id => `urgency:${urg_id}`);
+		const urgencies = await db.getObjects(keys, fields);
+		const result = await plugins.hooks.fire('filter:urgency.getFields', {
+			urg_ids: urg_ids,
+			urgencies: urgencies,
 			fields: fields,
 			keys: keys,
 		});
-		result.categories.forEach(category => modifyCategory(category, fields));
-		return result.categories;
+		result.urgencies.forEach(urgency => modifyUrgency(urgency, fields));
+		return result.urgencies;
 	};
 
-	Categories.getCategoryData = async function (cid) {
-		const categories = await Categories.getCategoriesFields([cid], []);
-		return categories && categories.length ? categories[0] : null;
+	Urgencies.getUrgencyData = async function (urg_id) {
+		const urgencies = await Urgencies.getUrgenciesFields([urg_id], []);
+		return urgencies && urgencies.length ? urgencies[0] : null;
 	};
 
-	Categories.getCategoriesData = async function (cids) {
-		return await Categories.getCategoriesFields(cids, []);
+	Urgencies.getUrgenciesData = async function (urg_ids) {
+		return await Urgencies.getUrgenciesFields(urg_ids, []);
 	};
 
-	Categories.getCategoryField = async function (cid, field) {
-		const category = await Categories.getCategoryFields(cid, [field]);
-		return category ? category[field] : null;
+	Urgencies.getUrgencyField = async function (urg_id, field) {
+		const urgency = await Urgencies.getUrgencyFields(urg_id, [field]);
+		return urgency ? urgency[field] : null;
 	};
 
-	Categories.getCategoryFields = async function (cid, fields) {
-		const categories = await Categories.getCategoriesFields([cid], fields);
-		return categories ? categories[0] : null;
+	Urgencies.getUrgencyFields = async function (urg_id, fields) {
+		const urgencies = await Urgencies.getUrgenciesFields([urg_id], fields);
+		return urgencies ? urgencies[0] : null;
 	};
 
-	Categories.getAllCategoryFields = async function (fields) {
-		const cids = await Categories.getAllCidsFromSet('categories:cid');
-		return await Categories.getCategoriesFields(cids, fields);
+	Urgencies.getAllUrgencyFields = async function (fields) {
+		const urg_ids = await Urgencies.getAllUrgidsFromSet('urgencies:urg_id');
+		return await Urgencies.getUrgenciesFields(urg_ids, fields);
 	};
 
-	Categories.setCategoryField = async function (cid, field, value) {
-		await db.setObjectField(`category:${cid}`, field, value);
+	Urgencies.setUrgencyField = async function (cid, field, value) {
+		await db.setObjectField(`urgency:${cid}`, field, value);
 	};
 
-	Categories.incrementCategoryFieldBy = async function (cid, field, value) {
-		await db.incrObjectFieldBy(`category:${cid}`, field, value);
+	Urgencies.incrementUrgencyFieldBy = async function (cid, field, value) {
+		await db.incrObjectFieldBy(`urgency:${cid}`, field, value);
 	};
 };
 
-function defaultIntField(category, fields, fieldName, defaultField) {
+function defaultIntField(urgency, fields, fieldName, defaultField) {
 	if (!fields.length || fields.includes(fieldName)) {
-		const useDefault = !category.hasOwnProperty(fieldName) ||
-			category[fieldName] === null ||
-			category[fieldName] === '' ||
-			!utils.isNumber(category[fieldName]);
+		const useDefault = !urgency.hasOwnProperty(fieldName) ||
+			urgency[fieldName] === null ||
+			urgency[fieldName] === '' ||
+			!utils.isNumber(urgency[fieldName]);
 
-		category[fieldName] = useDefault ? meta.config[defaultField] : category[fieldName];
+		urgency[fieldName] = useDefault ? meta.config[defaultField] : urgency[fieldName];
 	}
 }
 
-function modifyCategory(category, fields) {
-	if (!category) {
+function modifyUrgency(urgency, fields) {
+	if (!urgency) {
 		return;
 	}
 
-	defaultIntField(category, fields, 'minTags', 'minimumTagsPerTopic');
-	defaultIntField(category, fields, 'maxTags', 'maximumTagsPerTopic');
-	defaultIntField(category, fields, 'postQueue', 'postQueue');
+	defaultIntField(urgency, fields, 'minTags', 'minimumTagsPerTopic');
+	defaultIntField(urgency, fields, 'maxTags', 'maximumTagsPerTopic');
+	defaultIntField(urgency, fields, 'postQueue', 'postQueue');
 
-	db.parseIntFields(category, intFields, fields);
+	db.parseIntFields(urgency, intFields, fields);
 
 	const escapeFields = ['name', 'color', 'bgColor', 'backgroundImage', 'imageClass', 'class', 'link'];
 	escapeFields.forEach((field) => {
-		if (category.hasOwnProperty(field)) {
-			category[field] = validator.escape(String(category[field] || ''));
+		if (urgency.hasOwnProperty(field)) {
+			urgency[field] = validator.escape(String(urgency[field] || ''));
 		}
 	});
 
-	if (category.hasOwnProperty('icon')) {
-		category.icon = category.icon || 'hidden';
+	if (urgency.hasOwnProperty('icon')) {
+		urgency.icon = urgency.icon || 'hidden';
 	}
 
-	if (category.hasOwnProperty('post_count')) {
-		category.totalPostCount = category.post_count;
+	if (urgency.hasOwnProperty('post_count')) {
+		urgency.totalPostCount = urgency.post_count;
 	}
 
-	if (category.hasOwnProperty('topic_count')) {
-		category.totalTopicCount = category.topic_count;
+	if (urgency.hasOwnProperty('topic_count')) {
+		urgency.totalTopicCount = urgency.topic_count;
 	}
 
-	if (category.description) {
-		category.description = validator.escape(String(category.description));
-		category.descriptionParsed = category.descriptionParsed || category.description;
+	if (urgency.description) {
+		urgency.description = validator.escape(String(urgency.description));
+		urgency.descriptionParsed = urgency.descriptionParsed || urgency.description;
 	}
 }

--- a/src/urgencies/index.js
+++ b/src/urgencies/index.js
@@ -1,0 +1,378 @@
+
+'use strict';
+
+const _ = require('lodash');
+
+const db = require('../database');
+const user = require('../user');
+const topics = require('../topics');
+const plugins = require('../plugins');
+const cache = require('../cache');
+const meta = require('../meta');
+
+const Urgencies = module.exports;
+
+require('./data')(Urgencies);
+require('./create')(Urgencies);
+require('./search')(Urgencies);
+
+Urgencies.exists = async function (urg_ids) {
+	return await db.exists(
+		Array.isArray(urg_ids) ? urg_ids.map(urg_id => `urgency:${urg_id}`) : `urgency:${urg_ids}`
+	);
+};
+
+Urgencies.getUrgencyById = async function (data) {
+	const urgencies = await Urgencies.getUrgencies([data.urg_id]);
+	if (!urgencies[0]) {
+		return null;
+	}
+	const urgency = urgencies[0];
+	data.urgency = urgency;
+
+	const promises = [
+		Urgencies.getCategoryTopics(data),
+		Urgencies.getTopicCount(data),
+		Urgencies.getWatchState([data.urg_id], data.uid),
+	];
+
+	if (urgency.parentUrgid) {
+		promises.push(Urgencies.getCategoryData(urgency.parentUrgid));
+	}
+	const [topics, topicCount, watchState, , parent] = await Promise.all(promises);
+
+	urgency.topics = topics.topics;
+	urgency.nextStart = topics.nextStart;
+	urgency.topic_count = topicCount;
+	urgency.isWatched = watchState[0] === Urgencies.watchStates.watching;
+	urgency.isTracked = watchState[0] === Urgencies.watchStates.tracking;
+	urgency.isNotWatched = watchState[0] === Urgencies.watchStates.notwatching;
+	urgency.isIgnored = watchState[0] === Urgencies.watchStates.ignoring;
+	urgency.parent = parent;
+
+	calculateTopicPostCount(urgency);
+	const result = await plugins.hooks.fire('filter:urgency.get', {
+		urgency: urgency,
+		...data,
+	});
+	return { ...result.category };
+};
+
+Urgencies.onNewPostMade = async function (postData, urg_id) {
+	if (!postData) {
+		return;
+	}
+	const promises = [
+		db.sortedSetAdd(`urg_id:${urg_id}:pids`, postData.timestamp, postData.pid),
+		db.incrObjectField(`urgency:${urg_id}`, 'post_count'),
+	];
+	await Promise.all(promises);
+};
+
+Urgencies.getAllUrgIdsFromSet = async function (key) {
+	let urgIds = cache.get(key);
+	if (urgIds) {
+		return urgIds.slice();
+	}
+
+	urgIds = await db.getSortedSetRange(key, 0, -1);
+	urgIds = urgIds.map(urg_id => parseInt(urg_id, 10));
+	cache.set(key, urgIds);
+	return urgIds.slice();
+};
+
+Urgencies.getAllUrgencies = async function () {
+	const urg_ids = await Urgencies.getAllUrgIdsFromSet('urgencies:urg_id');
+	return await Urgencies.getUrgencies(urg_ids);
+};
+
+Urgencies.getModerators = async function (urg_id) {
+	const uids = await Urgencies.getModeratorUids([urg_id]);
+	return await user.getUsersFields(uids[0], ['uid', 'username', 'userslug', 'picture']);
+};
+
+Urgencies.getUrgencies = async function (urg_id) {
+	if (!Array.isArray(urg_id)) {
+		throw new Error('[[error:invalid-urg_id]]');
+	}
+
+	if (!urg_id.length) {
+		return [];
+	}
+
+	const [categories, tagWhitelist] = await Promise.all([
+		Urgencies.getCategoriesData(urg_id),
+		Urgencies.getTagWhitelist(urg_id),
+	]);
+	categories.forEach((urgency, i) => {
+		if (urgency) {
+			urgency.tagWhitelist = tagWhitelist[i];
+		}
+	});
+	return categories;
+};
+
+Urgencies.setUnread = async function (tree, urg_id, uid) {
+	if (uid <= 0) {
+		return;
+	}
+	const { unreadUrgids } = await topics.getUnreadData({
+		uid: uid,
+		urg_id: urg_id,
+	});
+	if (!unreadUrgids.length) {
+		return;
+	}
+
+	function setCategoryUnread(urgency) {
+		if (urgency) {
+			urgency.unread = false;
+			if (unreadUrgids.includes(urgency.urg_id)) {
+				urgency.unread = urgency.topic_count > 0 && true;
+			} else if (urgency.children.length) {
+				urgency.children.forEach(setCategoryUnread);
+				urgency.unread = urgency.children.some(c => c && c.unread);
+			}
+			urgency['unread-class'] = urgency.unread ? 'unread' : '';
+		}
+	}
+	tree.forEach(setCategoryUnread);
+};
+
+Urgencies.getTagWhitelist = async function (urg_ids) {
+	const cachedData = {};
+
+	const nonCachedUrgids = urg_ids.filter((urg_id) => {
+		const data = cache.get(`urg_id:${urg_id}:tag:whitelist`);
+		const isInCache = data !== undefined;
+		if (isInCache) {
+			cachedData[urg_id] = data;
+		}
+		return !isInCache;
+	});
+
+	if (!nonCachedUrgids.length) {
+		return urg_ids.map(urg_id => cachedData[urg_id]);
+	}
+
+	const keys = nonCachedUrgids.map(urg_id => `urg_id:${urg_id}:tag:whitelist`);
+	const data = await db.getSortedSetsMembers(keys);
+
+	nonCachedUrgids.forEach((urg_id, index) => {
+		cachedData[urg_id] = data[index];
+		cache.set(`urg_id:${urg_id}:tag:whitelist`, data[index]);
+	});
+	return urg_ids.map(urg_id => cachedData[urg_id]);
+};
+
+// remove system tags from tag whitelist for non privileged user
+Urgencies.filterTagWhitelist = function (tagWhitelist, isAdminOrMod) {
+	const systemTags = (meta.config.systemTags || '').split(',');
+	if (!isAdminOrMod && systemTags.length) {
+		return tagWhitelist.filter(tag => !systemTags.includes(tag));
+	}
+	return tagWhitelist;
+};
+
+function calculateTopicPostCount(urgency) {
+	if (!urgency) {
+		return;
+	}
+
+	let postCount = urgency.post_count;
+	let topicCount = urgency.topic_count;
+	if (Array.isArray(urgency.children)) {
+		urgency.children.forEach((child) => {
+			calculateTopicPostCount(child);
+			postCount += parseInt(child.totalPostCount, 10) || 0;
+			topicCount += parseInt(child.totalTopicCount, 10) || 0;
+		});
+	}
+
+	urgency.totalPostCount = postCount;
+	urgency.totalTopicCount = topicCount;
+}
+Urgencies.calculateTopicPostCount = calculateTopicPostCount;
+
+Urgencies.getParents = async function (urg_ids) {
+	const urgenciesData = await Urgencies.getCategoriesFields(urg_ids, ['parentUrgid']);
+	const parentUrgids = urgenciesData.filter(c => c && c.parentUrgid).map(c => c.parentUrgid);
+	if (!parentUrgids.length) {
+		return urg_ids.map(() => null);
+	}
+	const parentData = await Urgencies.getCategoriesData(parentUrgids);
+	const urgidToParent = _.zipObject(parentUrgids, parentData);
+	return urgenciesData.map(category => urgidToParent[category.parentUrgid]);
+};
+
+Urgencies.getParentUrgids = async function (currentUrgid) {
+	let cid = currentUrgid;
+	const parents = [];
+	while (parseInt(cid, 10)) {
+		// eslint-disable-next-line
+		cid = await Urgencies.getCategoryField(cid, 'parentUrgid');
+		if (cid) {
+			parents.unshift(cid);
+		}
+	}
+	return parents;
+};
+
+Urgencies.getChildrenUrgids = async function (rootUrgid) {
+	let allUrgids = [];
+	async function recursive(keys) {
+		let childrenUrgids = await db.getSortedSetRange(keys, 0, -1);
+
+		childrenUrgids = childrenUrgids.filter(urg_id => !allUrgids.includes(parseInt(urg_id, 10)));
+		if (!childrenUrgids.length) {
+			return;
+		}
+		keys = childrenUrgids.map(urg_id => `urg_id:${urg_id}:children`);
+		childrenUrgids.forEach(urg_id => allUrgids.push(parseInt(urg_id, 10)));
+		await recursive(keys);
+	}
+	const key = `urg_id:${rootUrgid}:children`;
+	const cacheKey = `${key}:all`;
+	const childrenCids = cache.get(cacheKey);
+	if (childrenCids) {
+		return childrenCids.slice();
+	}
+
+	await recursive(key);
+	allUrgids = _.uniq(allUrgids);
+	cache.set(cacheKey, allUrgids);
+	return allUrgids.slice();
+};
+
+Urgencies.flattenCategories = function (allUrgencies, urgencyData) {
+	urgencyData.forEach((urgency) => {
+		if (urgency) {
+			allUrgencies.push(urgency);
+
+			if (Array.isArray(urgency.children) && urgency.children.length) {
+				Urgencies.flattenCategories(allUrgencies, urgency.children);
+			}
+		}
+	});
+};
+
+/**
+ * build tree from flat list of categories
+ *
+ * @param urgencies {array} flat list of categories
+ * @param parentUrgid {number} start from 0 to build full tree
+ */
+Urgencies.getTree = function (urgencies, parentUrgid) {
+	parentUrgid = parentUrgid || 0;
+	const cids = urgencies.map(urgency => urgency && urgency.cid);
+	const cidToCategory = {};
+	const parents = {};
+	cids.forEach((urg_id, index) => {
+		if (urg_id) {
+			urgencies[index].children = undefined;
+			cidToCategory[urg_id] = urgencies[index];
+			parents[urg_id] = { ...urgencies[index] };
+		}
+	});
+
+	const tree = [];
+
+	urgencies.forEach((urgency) => {
+		if (urgency) {
+			urgency.children = urgency.children || [];
+			if (!urgency.cid) {
+				return;
+			}
+			if (!urgency.hasOwnProperty('parentUrgid') || urgency.parentUrgid === null) {
+				urgency.parentUrgid = 0;
+			}
+			if (urgency.parentUrgid === parentUrgid) {
+				tree.push(urgency);
+				urgency.parent = parents[parentUrgid];
+			} else {
+				const parent = cidToCategory[urgency.parentUrgid];
+				if (parent && parent.cid !== urgency.cid) {
+					urgency.parent = parents[urgency.parentUrgid];
+					parent.children = parent.children || [];
+					parent.children.push(urgency);
+				}
+			}
+		}
+	});
+	function sortTree(tree) {
+		tree.sort((a, b) => {
+			if (a.order !== b.order) {
+				return a.order - b.order;
+			}
+			return a.cid - b.cid;
+		});
+		tree.forEach((urgency) => {
+			if (urgency && Array.isArray(urgency.children)) {
+				sortTree(urgency.children);
+			}
+		});
+	}
+	sortTree(tree);
+
+	urgencies.forEach(c => calculateTopicPostCount(c));
+	return tree;
+};
+
+Urgencies.buildForSelect = async function (uid, privilege, fields) {
+	const cids = await Urgencies.getCidsByPrivilege('categories:cid', uid, privilege);
+	return await getSelectData(cids, fields);
+};
+
+Urgencies.buildForSelectAll = async function (fields) {
+	const cids = await Urgencies.getAllUrgIdsFromSet('categories:cid');
+	return await getSelectData(cids, fields);
+};
+
+async function getSelectData(cids, fields) {
+	const categoryData = await Urgencies.getCategoriesData(cids);
+	const tree = Urgencies.getTree(categoryData);
+	return Urgencies.buildForSelectUrgencies(tree, fields);
+}
+
+Urgencies.buildForSelectUrgencies = function (urgencies, fields, parentUrgid) {
+	function recursive({ ...urgency }, urgenciesData, level, depth) {
+		const bullet = level ? '&bull; ' : '';
+		urgency.value = urgency.cid;
+		urgency.level = level;
+		urgency.text = level + bullet + urgency.name;
+		urgency.depth = depth;
+		urgenciesData.push(urgency);
+		if (Array.isArray(urgency.children)) {
+			urgency.children.forEach(child => recursive(child, urgenciesData, `&nbsp;&nbsp;&nbsp;&nbsp;${level}`, depth + 1));
+		}
+	}
+	parentUrgid = parentUrgid || 0;
+	const urgenciesData = [];
+
+	const rootUrgencies = urgencies.filter(urgency => urgency && urgency.parentUrgid === parentUrgid);
+
+	rootUrgencies.sort((a, b) => {
+		if (a.order !== b.order) {
+			return a.order - b.order;
+		}
+		return a.cid - b.cid;
+	});
+
+	rootUrgencies.forEach(urgency => recursive(urgency, urgenciesData, '', 0));
+
+	const pickFields = [
+		'cid', 'name', 'level', 'icon', 'parentUrgid',
+		'color', 'bgColor', 'backgroundImage', 'imageClass',
+	];
+	fields = fields || [];
+	if (fields.includes('text') && fields.includes('value')) {
+		return urgenciesData.map(category => _.pick(category, fields));
+	}
+	if (fields.length) {
+		pickFields.push(...fields);
+	}
+
+	return urgenciesData.map(category => _.pick(category, pickFields));
+};
+
+require('../promisify')(Urgencies);

--- a/src/urgencies/index.js
+++ b/src/urgencies/index.js
@@ -53,7 +53,6 @@ Urgencies.getAllUrgIdsFromSet = async function (key) {
 	if (urgIds) {
 		return urgIds.slice();
 	}
-	console.log('getAllUrgIdsFromSet', key);
 	urgIds = await db.getSortedSetRange(key, 0, -1);
 	urgIds = urgIds.map(urg_id => parseInt(urg_id, 10));
 	cache.set(key, urgIds);

--- a/src/urgencies/search.js
+++ b/src/urgencies/search.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const _ = require('lodash');
+
+const privileges = require('../privileges');
+const plugins = require('../plugins');
+const db = require('../database');
+
+module.exports = function (Categories) {
+	Categories.search = async function (data) {
+		const query = data.query || '';
+		const page = data.page || 1;
+		const uid = data.uid || 0;
+		const paginate = data.hasOwnProperty('paginate') ? data.paginate : true;
+
+		const startTime = process.hrtime();
+
+		let cids = await findCids(query, data.hardCap);
+
+		const result = await plugins.hooks.fire('filter:categories.search', {
+			data: data,
+			cids: cids,
+			uid: uid,
+		});
+		cids = await privileges.categories.filterCids('find', result.cids, uid);
+
+		const searchResult = {
+			matchCount: cids.length,
+		};
+
+		if (paginate) {
+			const resultsPerPage = data.resultsPerPage || 50;
+			const start = Math.max(0, page - 1) * resultsPerPage;
+			const stop = start + resultsPerPage;
+			searchResult.pageCount = Math.ceil(cids.length / resultsPerPage);
+			cids = cids.slice(start, stop);
+		}
+
+		const childrenCids = await getChildrenCids(cids, uid);
+		const uniqCids = _.uniq(cids.concat(childrenCids));
+		const categoryData = await Categories.getCategories(uniqCids);
+
+		Categories.getTree(categoryData, 0);
+		await Categories.getRecentTopicReplies(categoryData, uid, data.qs);
+		categoryData.forEach((category) => {
+			if (category && Array.isArray(category.children)) {
+				category.children = category.children.slice(0, category.subCategoriesPerPage);
+				category.children.forEach((child) => {
+					child.children = undefined;
+				});
+			}
+		});
+
+		categoryData.sort((c1, c2) => {
+			if (c1.parentCid !== c2.parentCid) {
+				return c1.parentCid - c2.parentCid;
+			}
+			return c1.order - c2.order;
+		});
+		searchResult.timing = (process.elapsedTimeSince(startTime) / 1000).toFixed(2);
+		searchResult.categories = categoryData.filter(c => cids.includes(c.cid));
+		return searchResult;
+	};
+
+	async function findCids(query, hardCap) {
+		if (!query || String(query).length < 2) {
+			return [];
+		}
+		const data = await db.getSortedSetScan({
+			key: 'categories:name',
+			match: `*${String(query).toLowerCase()}*`,
+			limit: hardCap || 500,
+		});
+		return data.map(data => parseInt(data.split(':').pop(), 10));
+	}
+
+	async function getChildrenCids(cids, uid) {
+		const childrenCids = await Promise.all(cids.map(cid => Categories.getChildrenCids(cid)));
+		return await privileges.categories.filterCids('find', _.flatten(childrenCids), uid);
+	}
+};


### PR DESCRIPTION
## Que?

Se implemento la logica y funcionalidad de agregar urgencias a los post de la pagina, generando y modificando endpoints para la consulta de urgencias y modificacion de urgencia de los posts.

## Por que?

Dicha implementacion es parte de la iniciativa de categorizar por nivel de urgencia los posts para que el profesor sepa la importancia de cada uno de los comentarios o preguntas que los estudiantes escriban.

## Como?

Primeramente se definieron los niveles de urgencia en el archivo `install/data/urgencies.json`, de forma que al inicializar la aplicacion se agreguen a la Base de Datos al ejecutarse el archivo `src/install.js`. Posteriormente, se creo el directorio `src/urgencies`, donde se generaron  los metodos para crear y consultar las urgencias.

Luego, se crearon controladores que manejaran las peticiones de relacionadas a las urgencias, la edicion y creacion de posts con el parametro de urgencia en el directorio `src/controllers`. Finalmente, se agregaron rutas a la API en el directorio `src/routes`, las cuales reciben todas las peticiones definidas en los controladores.

## Pruebas

*Nota*: Se tomara como URL a la url base de la pagina 

- Se realizaron pruebas para obtener todas las urgencias creadas con `URL/api/urgency`
- Para obtener una urgencia usando su identificar se uso `URL/api/urgency/:urg_id`
- Se probo la obtencion de posts urgentes segun el usuario con la ruta `URL/api/v3/posts/:uid/urgency`
- Se hicieron pruebas en la edicion del estado de urgencia con `URL/api/v3/posts/:pid`

## Capturas de Pantalla

Ninguna

## Algo mas?

- De momento no se han modificado las pruebas para tomar en cuenta estos cambios en los resultados de las peticiones.
- Las pruebas de eslint pasan satisfactoriamente.
- Se modifico el archivo `.gitignore` para ocultar el archivo `dump.rbd` que genera la Base de Datos al ejecutarse.

## Issues Relacionados

- #17 
- #19 