### PR TITLE
Conexion de front y back para el listado de urgencias

### DIFF
--- a/nodebb-plugin-new/templates/partials/topic/post.tpl
+++ b/nodebb-plugin-new/templates/partials/topic/post.tpl
@@ -55,7 +55,7 @@
 			{{{ end }}}
 			
 			<div class="d-flex align-items-center gap-1 flex-grow-1 justify-content-end">
-				<select class="form-select-sm me-2 bg-primary text-white border-0" aria-label="Small select example">
+				<select class="form-select-sm me-2 bg-primary text-white border-0 urgency-select" aria-label="Small select example" data-pid="{./pid}" data-uid="{posts.user.uid}" data-content="{posts.content}">
 					<option value="1" {{{ if equals(posts.urg_id,"1") }}} selected {{{ end }}}>No urgency</option>
 					<option value="2" {{{ if equals(posts.urg_id,"2") }}} selected {{{ end }}}>High</option>
 					<option value="3" {{{ if equals(posts.urg_id,"3") }}} selected {{{ end }}}>Medium</option>

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -19,6 +19,42 @@ require('./ajaxify');
 
 app = window.app || {};
 
+const select = document.querySelectorAll('.urgency-select');
+if (select && select.length) {
+	select.forEach((el) => {
+		el.addEventListener('change', async (e) => {
+			const pid = parseInt(e.target.getAttribute('data-pid'), 10);
+			const uid = parseInt(e.target.getAttribute('data-uid'), 10);
+			const { content } = (await fetch(`/api/v3/posts/${pid}`).then(res => res.json())).response;
+			const urg_id = e.target.value;
+
+			const { csrf_token } = await fetch('/api/config').then(res => res.json());
+
+			const data = {
+				urg_id,
+				content: content,
+				uid,
+				pid,
+			};
+
+			const res = await fetch(`/api/v3/posts/${pid}`, {
+				method: 'PUT',
+				headers: {
+					'Content-Type': 'application/json',
+					'x-csrf-token': csrf_token,
+				},
+				body: JSON.stringify(data),
+			});
+
+			if (res.status === 200) {
+				console.log('Urgency updated');
+			} else {
+				console.error('Error updating urgency', res);
+			}
+		});
+	});
+}
+
 Object.defineProperty(app, 'isFocused', {
 	get() {
 		return document.visibilityState === 'visible';


### PR DESCRIPTION
## ¿Qué?

Se implementó la conexión del backend con el frontend para el cambio de los estados de urgencia.

## ¿Por qué?

Esta implementación permite modificar el estado de urgencia de una publicación, guardando dicho cambio en la Base de Datos y mostrando el cambio en pantalla.

## ¿Cómo?

Se realizó un manejador de eventos en `public/src/app.js` para el componente `<select>` creado para manejar las urgencias, que al detectar un cambio en el valor de la urgencia, modifica el valor de la urgencia para ese post.

## Pruebas

- Se realizaron pruebas para verificar que los cambios de urgencia se mostraban en el Frontend y se almacenaban en la Base de Datos correctamente.

## Capturas de Pantalla

Ninguna

## Algo mas?

- Las pruebas de eslint pasan satisfactoriamente.
- Hace falta hacer la activación del plugin nodebb-plugin-new manualmente haciendo: 

```bash
./nodebb activate nodebb-plugin-new
npm i && ./nodebb build && ./nodebb restart
```

## Issues Relacionados

- #21 