### PR TITLE
Creación los grupos para los roles estudiantes y profesores

### DIFF
--- a/src/controllers/authentication.js
+++ b/src/controllers/authentication.js
@@ -54,10 +54,36 @@ async function registerAndLoginUser(req, res, userData) {
 	}
 	// Join the user to the default group, if they are a student or professor
 	if (userData.rol === 'student') {
+		const exists = await groups.exists('Estudiantes');
+		if (!exists) {
+			await groups.create({
+				name: 'Estudiantes',
+				userTitle: 'Estudiantes',
+				description: 'Grupo para estudiantes',
+				hidden: 0,
+				private: 1,
+				disableJoinRequests: 1,
+				disableLeave: 1,
+			});
+			await groups.show('Estudiantes');
+		}
 		await groups.join('Estudiantes', uid);
 	}
 
 	if (userData.rol === 'professor') {
+		const exists = await groups.exists('Profesores');
+		if (!exists) {
+			await groups.create({
+				name: 'Profesores',
+				userTitle: 'Profesores',
+				description: 'Grupo para profesores',
+				hidden: 0,
+				private: 1,
+				disableJoinRequests: 1,
+				disableLeave: 1,
+			});
+			await groups.show('Profesores');
+		}
 		await groups.join('Profesores', uid);
 	}
 


### PR DESCRIPTION
## ¿Qué?

Se implementó la funcionalidad para crear y unir automáticamente a los usuarios a los grupos predeterminados de estudiantes y profesores al momento de registrarse.

## ¿Por qué?

Esta implementación asegura que los usuarios con roles de estudiantes y profesores sean asignados automáticamente a sus respectivos grupos, facilitando la gestión y organización de usuarios en la plataforma.

## ¿Cómo?

Se añadió lógica en el archivo `authentication.js` para verificar el rol del usuario durante el registro. Si el usuario es un estudiante o profesor, se crea y se une automáticamente al grupo correspondiente (`Estudiantes` o `Profesores`).

## Pruebas

- Se realizaron pruebas para verificar que los usuarios con roles de estudiantes y profesores se unen automáticamente a sus respectivos grupos al registrarse.
- Se verificó que los grupos se crean correctamente si no existen.

## Capturas de Pantalla

Ninguna

## Algo más?

- Las pruebas de eslint pasan satisfactoriamente.

## Issues Relacionados

- #23