### PR TITLE
Actualizar selección de urgencia para cargar dinámicamente las opciones

### DIFF
--- a/nodebb-plugin-new/templates/partials/topic/post.tpl
+++ b/nodebb-plugin-new/templates/partials/topic/post.tpl
@@ -55,11 +55,7 @@
 			{{{ end }}}
 			
 			<div class="d-flex align-items-center gap-1 flex-grow-1 justify-content-end">
-				<select class="form-select-sm me-2 bg-primary text-white border-0 urgency-select" aria-label="Small select example" data-pid="{./pid}" data-uid="{posts.user.uid}" data-content="{posts.content}">
-					<option value="1" {{{ if equals(posts.urg_id,"1") }}} selected {{{ end }}}>No urgency</option>
-					<option value="2" {{{ if equals(posts.urg_id,"2") }}} selected {{{ end }}}>High</option>
-					<option value="3" {{{ if equals(posts.urg_id,"3") }}} selected {{{ end }}}>Medium</option>
-					<option value="4" {{{ if equals(posts.urg_id,"4") }}} selected {{{ end }}}>Low</option>
+				<select class="form-select-sm me-2 bg-primary text-white border-0 urgency-select" data-urg="{posts.urg_id}" data-pid="{./pid}" data-uid="{posts.user.uid}" data-content="{posts.content}">
 				</select>
 				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
 				<a href="{config.relative_path}/post/{./pid}" class="post-index text-muted d-none d-md-inline">#{increment(./index, "1")}</a>

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -19,9 +19,21 @@ require('./ajaxify');
 
 app = window.app || {};
 
+async function getUrgency() {
+	const urgencies = await fetch('/api/urgency').then(res => res.json());
+	return urgencies;
+}
+
 const select = document.querySelectorAll('.urgency-select');
+
 if (select && select.length) {
-	select.forEach((el) => {
+	select.forEach(async (el) => {
+		const urgencies = await getUrgency();
+
+		const urg_id = el.getAttribute('data-urg');
+		const options = urgencies.map(urgency => `<option value="${urgency.urg_id}" ${urg_id === urgency.urg_id ? 'selected' : ''}>${urgency.name}</option>`);
+		el.innerHTML = options.join('');
+
 		el.addEventListener('change', async (e) => {
 			const pid = parseInt(e.target.getAttribute('data-pid'), 10);
 			const uid = parseInt(e.target.getAttribute('data-uid'), 10);


### PR DESCRIPTION
## Que?

Se implemento una forma dinamica de listar las urgencias de los posts, de forma de que si se agrega una urgencia mas, se pueda revisar facilmente e integrarse con el resto de la aplicacion.

## Por que?

Dicha implementacion es parte de la iniciativa de categorizar por nivel de urgencia los posts para que el profesor sepa la importancia de cada uno de los comentarios o preguntas que los estudiantes escriban. Ademas, ayuda a la configuracion de las urgencias.

## Como?

Se eliminaron las opciones predefinidas en `post.tpl`. Ademas, se agrego el codigo que hace las llamadas a la api para listar las categorias de urgencia en `public/src/app.js`.
