### PR TITLE
Agregar seguimiento del estado de respuesta para posts

### DIFF
--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -123,6 +123,8 @@ postsAPI.edit = async function (caller, data) {
 			oldContent: editResult.post.oldContent,
 			newContent: editResult.post.newContent,
 			urg_id: data.urg_id,
+			// answered is a boolean, but we need to store it as a string
+			answered: data.answered,
 		});
 	}
 

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -184,3 +184,37 @@ Posts.getUrgentPosts = async (req, res) => {
 	const urgentPosts = await posts.getUrgentPosts(req.uid);
 	helpers.formatApiResponse(200, res, urgentPosts);
 };
+
+Posts.getAnsweredStatus = async (req, res) => {
+	/**
+	 * Retrieves the answered status of a post.
+	 *
+	 * @param {string} pid - The ID of the post to check.
+	 * @returns - An Response object containing the answered status of the post.
+	 */
+	const answeredStatus = await posts.getAnsweredStatus(req.params.pid);
+	helpers.formatApiResponse(200, res, answeredStatus);
+}
+
+Posts.toggleAnswered = async (req, res) => {
+	/**
+	 * Toggles the "answered" status of a post.
+	 *
+	 * @param {string} req.params.pid - The ID of the post to toggle.
+	 * @returns - An Response object containing the new answered status of the post.
+	 */
+	// Get the current answered status of the post
+	const answeredStatus = await posts.getAnsweredStatus(req.params.pid);
+	// Toggle the answered status
+	if (answeredStatus === 'false') {
+		await posts.setPostField(req.params.pid, 'answered', true);
+	} else {
+		await posts.setPostField(req.params.pid, 'answered', false);
+	}
+
+	// Get the new answered status
+	const newStatus = await posts.getAnsweredStatus(req.params.pid);
+
+	// Return the new status
+	helpers.formatApiResponse(200, res, newStatus);
+}

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -38,6 +38,8 @@ module.exports = function (Posts) {
 			content: content,
 			timestamp: timestamp,
 			urg_id: urg_id,
+			// At this point, the post is not been answered
+			answered: false
 		};
 
 		if (data.toPid) {
@@ -49,6 +51,9 @@ module.exports = function (Posts) {
 		if (data.handle && !parseInt(uid, 10)) {
 			postData.handle = data.handle;
 		}
+
+		// If the post has been answered, set the answered field to true
+		postData.answered = data.answered || false;
 
 		let result = await plugins.hooks.fire('filter:post.create', {
 			post: postData,

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -33,6 +33,17 @@ module.exports = function (Posts) {
 		return urgency ? { ...posts[0], urgency } : null;
 	};
 
+	Posts.getAnsweredStatus = async function (pid) {
+		/**
+		 * Retrieves the answered status of a post.
+		 *
+		 * @param {number} pid - The ID of the post to retrieve.
+		 * @returns {string} True if the post has been answered, false otherwise.
+		 */
+		const post = await Posts.getPostFields(pid, ['answered']);
+		return post ? post.answered : false;
+	}
+
 	Posts.getPostsData = async function (pids) {
 		const posts = await Posts.getPostsFields(pids, []);
 		const urgencies = await Promise.all(posts.map(post => getUrgencyById({ urg_id: post.urg_id })));

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -38,6 +38,8 @@ module.exports = function (Posts) {
 		const oldContent = postData.content; // for diffing purposes
 		const editPostData = getEditPostData(data, topicData, postData);
 		const urg_id = data.urg_id || postData.urg_id;
+		// we need to ensure that the post is marked as answered if it was answered before
+		const answered = data.answered || postData.answered;
 		editPostData.urg_id = urg_id;
 
 		if (data.handle) {
@@ -50,6 +52,8 @@ module.exports = function (Posts) {
 			data: data,
 			uid: data.uid,
 			urg_id: urg_id,
+			// we need to ensure that the post is marked as answered if it was answered before
+			answered: answered,
 		});
 
 		const [editor, topic] = await Promise.all([
@@ -67,6 +71,7 @@ module.exports = function (Posts) {
 				pid: data.pid,
 				uid: data.uid,
 				urg_id: data.urg_id || postData.urg_id,
+				answered: data.answered || postData.answered,
 				oldContent: oldContent,
 				newContent: data.content,
 				edited: editPostData.edited,

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -13,6 +13,12 @@ module.exports = function () {
 	setupApiRoute(router, 'get', '/:pid', [middleware.assert.post], controllers.write.posts.get);
 	// There is no POST route because you POST to a topic to create a new post. Intuitive, no?
 	setupApiRoute(router, 'put', '/:pid', [middleware.ensureLoggedIn, middleware.checkRequired.bind(null, ['content'])], controllers.write.posts.edit);
+	
+	// This route is used to get the post's answer status
+	setupApiRoute(router, 'get', '/:pid/answered', [], controllers.write.posts.getAnsweredStatus);
+	// This route is used to toggle the post's answer status
+	setupApiRoute(router, 'put', '/:pid/answered', middlewares, controllers.write.posts.toggleAnswered);
+
 	setupApiRoute(router, 'delete', '/:pid', middlewares, controllers.write.posts.purge);
 
 	setupApiRoute(router, 'get', '/:uid/urgency', [], controllers.write.posts.getUrgentPosts);


### PR DESCRIPTION
## Qué?
Se implementó un campo "answered" para rastrear el estado de respuesta de los posts, junto con métodos y rutas para obtener y cambiar este estado. Esta mejora optimiza la funcionalidad de gestión de posts.
## Por qué?
Esta implementación permite tener un mejor control y visibilidad sobre cuáles posts han sido respondidos y cuáles aún requieren atención, mejorando así la gestión y seguimiento de las interacciones en la plataforma.
## Cómo?
Se agregó un nuevo campo "answered" en el modelo de posts, se implementaron las rutas necesarias en la API para manejar este estado, y se desarrollaron los métodos correspondientes para obtener y modificar el estado de respuesta de los posts.
## Issues Relacionados
#28