### PR TITLE
Agregar Endpoint para la obtencion de Post bassados en su urgencia y si fueron contestados o no

### DIFF
--- a/nodebb-plugin-new/templates/partials/topic/post.tpl
+++ b/nodebb-plugin-new/templates/partials/topic/post.tpl
@@ -55,7 +55,11 @@
 			{{{ end }}}
 			
 			<div class="d-flex align-items-center gap-1 flex-grow-1 justify-content-end">
-				<select class="form-select-sm me-2 bg-primary text-white border-0 urgency-select" data-urg="{posts.urg_id}" data-pid="{./pid}" data-uid="{posts.user.uid}" data-content="{posts.content}">
+				<select class="form-select-sm me-2 bg-primary text-white border-0 urgency-select" aria-label="Small select example" data-pid="{./pid}" data-uid="{posts.user.uid}" data-content="{posts.content}">
+					<option value="1" {{{ if equals(posts.urg_id,"1") }}} selected {{{ end }}}>No urgency</option>
+					<option value="2" {{{ if equals(posts.urg_id,"2") }}} selected {{{ end }}}>High</option>
+					<option value="3" {{{ if equals(posts.urg_id,"3") }}} selected {{{ end }}}>Medium</option>
+					<option value="4" {{{ if equals(posts.urg_id,"4") }}} selected {{{ end }}}>Low</option>
 				</select>
 				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
 				<a href="{config.relative_path}/post/{./pid}" class="post-index text-muted d-none d-md-inline">#{increment(./index, "1")}</a>

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -19,21 +19,9 @@ require('./ajaxify');
 
 app = window.app || {};
 
-async function getUrgency() {
-	const urgencies = await fetch('/api/urgency').then(res => res.json());
-	return urgencies;
-}
-
 const select = document.querySelectorAll('.urgency-select');
-
 if (select && select.length) {
-	select.forEach(async (el) => {
-		const urgencies = await getUrgency();
-
-		const urg_id = el.getAttribute('data-urg');
-		const options = urgencies.map(urgency => `<option value="${urgency.urg_id}" ${urg_id === urgency.urg_id ? 'selected' : ''}>${urgency.name}</option>`);
-		el.innerHTML = options.join('');
-
+	select.forEach((el) => {
 		el.addEventListener('change', async (e) => {
 			const pid = parseInt(e.target.getAttribute('data-pid'), 10);
 			const uid = parseInt(e.target.getAttribute('data-uid'), 10);

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -37,7 +37,7 @@ if (select && select.length) {
 				pid,
 			};
 
-			const res = await fetch(`/api/v3/posts/${pid}`, {
+			await fetch(`/api/v3/posts/${pid}`, {
 				method: 'PUT',
 				headers: {
 					'Content-Type': 'application/json',
@@ -45,12 +45,6 @@ if (select && select.length) {
 				},
 				body: JSON.stringify(data),
 			});
-
-			if (res.status === 200) {
-				console.log('Urgency updated');
-			} else {
-				console.error('Error updating urgency', res);
-			}
 		});
 	});
 }

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -157,6 +157,34 @@ postsAPI.edit = async function (caller, data) {
 	return returnData;
 };
 
+postsAPI.editAnswered = async function (caller, data) {
+	if (!data || !data.pid) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	const tid = await posts.getPostField(data.pid, 'tid');
+	const canEdit = await privileges.categories.can('topics:write', tid, caller.uid);
+	if (!canEdit) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	const req = apiHelpers.buildReqObject(caller);
+
+	const postData = await posts.editAnswered({ pid: data.pid, answered: data.answered, uid: caller.uid, req });
+
+	const topicData = await topics.getTopicFields(tid, ['title']);
+	await events.log({
+		type: 'post-edit',
+		uid: caller.uid,
+		ip: caller.ip,
+		pid: data.pid,
+		tid: tid,
+		title: topicData.title,
+		answered: data.answered,
+	});
+
+	return postData;
+};
+
 postsAPI.delete = async function (caller, data) {
 	await deleteOrRestore(caller, data, {
 		command: 'delete',

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -84,6 +84,16 @@ Posts.edit = async (req, res) => {
 	helpers.formatApiResponse(200, res, editResult);
 };
 
+Posts.editAnswered = async (req, res) => {
+	const editResult = await api.posts.editAnswered(req, {
+		...req.body,
+		pid: req.params.pid,
+		uid: req.uid,
+	});
+
+	helpers.formatApiResponse(200, res, editResult);
+};
+
 Posts.purge = async (req, res) => {
 	await api.posts.purge(req, { pid: req.params.pid });
 	helpers.formatApiResponse(200, res);
@@ -182,5 +192,10 @@ Posts.getReplies = async (req, res) => {
 
 Posts.getUrgentPosts = async (req, res) => {
 	const urgentPosts = await posts.getUrgentPosts(req.uid);
+	helpers.formatApiResponse(200, res, urgentPosts);
+};
+
+Posts.getUnansweredUrgentPosts = async (req, res) => {
+	const urgentPosts = await posts.getUnansweredUrgentPosts(req.uid);
 	helpers.formatApiResponse(200, res, urgentPosts);
 };

--- a/src/install.js
+++ b/src/install.js
@@ -459,7 +459,7 @@ async function createCategories() {
 	}
 }
 
-async function createUgrencies() {
+async function createUrgencies() {
 	const Urgencies = require('./urgencies');
 	const db = require('./database');
 	const cids = await db.getSortedSetRange('urgencies:urg_id', 0, -1);
@@ -475,8 +475,7 @@ async function createUgrencies() {
 	);
 	for (const categoryData of default_urgencies) {
 		// eslint-disable-next-line no-await-in-loop
-		const p = await Urgencies.create(categoryData);
-		console.log(p);
+		await Urgencies.create(categoryData);
 	}
 }
 
@@ -606,7 +605,7 @@ install.setup = async function () {
 		await setupDefaultConfigs();
 		await enableDefaultTheme();
 		await createCategories();
-		await createUgrencies();
+		await createUrgencies();
 		await createDefaultUserGroups();
 		const adminInfo = await createAdministrator();
 		await createGlobalModeratorsGroup();

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -10,7 +10,6 @@ const topics = require('../topics');
 const categories = require('../categories');
 const groups = require('../groups');
 const privileges = require('../privileges');
-// const urgency = require('../urgencies');
 
 module.exports = function (Posts) {
 	Posts.create = async function (data) {
@@ -21,6 +20,7 @@ module.exports = function (Posts) {
 		const timestamp = data.timestamp || Date.now();
 		const isMain = data.isMain || false;
 		const urg_id = data.urg_id ? parseInt(data.urg_id, 10) : 1;
+		const answered = data.answered || 0;
 
 		if (!uid && parseInt(uid, 10) !== 0) {
 			throw new Error('[[error:invalid-uid]]');
@@ -38,6 +38,7 @@ module.exports = function (Posts) {
 			content: content,
 			timestamp: timestamp,
 			urg_id: urg_id,
+			answered: answered,
 		};
 
 		if (data.toPid) {

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -8,7 +8,7 @@ const utils = require('../utils');
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
-	'replies', 'bookmarks',
+	'replies', 'bookmarks', 'answered',
 ];
 
 module.exports = function (Posts) {

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -38,6 +38,7 @@ module.exports = function (Posts) {
 		const oldContent = postData.content; // for diffing purposes
 		const editPostData = getEditPostData(data, topicData, postData);
 		const urg_id = data.urg_id || postData.urg_id;
+		const answered = data.answered || postData.answered;
 		editPostData.urg_id = urg_id;
 
 		if (data.handle) {
@@ -50,6 +51,7 @@ module.exports = function (Posts) {
 			data: data,
 			uid: data.uid,
 			urg_id: urg_id,
+			answered: answered,
 		});
 
 		const [editor, topic] = await Promise.all([

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -110,6 +110,81 @@ module.exports = function (Posts) {
 		};
 	};
 
+	Posts.editAnswered = async function (data) {
+		const canEdit = await privileges.posts.canEdit(data.pid, data.uid);
+		if (!canEdit.flag) {
+			throw new Error(canEdit.message);
+		}
+		const postData = await Posts.getPostData(data.pid);
+		if (!postData) {
+			throw new Error('[[error:no-post]]');
+		}
+
+		const topicData = await topics.getTopicFields(postData.tid, [
+			'cid', 'mainPid', 'title', 'timestamp', 'scheduled', 'slug', 'tags',
+		]);
+
+		await scheduledTopicCheck(data, topicData);
+
+		const oldContent = postData.content; // for diffing purposes
+		const editPostData = getEditPostData(data, topicData, postData);
+		const answered = data.answered || postData.answered;
+		editPostData.answered = answered;
+
+		if (data.handle) {
+			editPostData.handle = data.handle;
+		}
+
+		const result = await plugins.hooks.fire('filter:post.edit', {
+			req: data.req,
+			post: editPostData,
+			data: data,
+			uid: data.uid,
+			answered: answered,
+		});
+
+		const [editor, topic] = await Promise.all([
+			user.getUserFields(data.uid, ['username', 'userslug']),
+			editMainPost(data, postData, topicData),
+		]);
+
+		await Posts.setPostFields(data.pid, result.post);
+		await Posts.uploads.sync(data.pid);
+
+		// Normalize data prior to constructing returnPostData (match types with getPostSummaryByPids)
+		postData.deleted = !!postData.deleted;
+
+		const returnPostData = { ...postData, ...result.post };
+		returnPostData.cid = topic.cid;
+		returnPostData.answered = answered;
+		returnPostData.topic = topic;
+		returnPostData.editedISO = utils.toISOString(editPostData.edited);
+		returnPostData.changed = false;
+		returnPostData.oldContent = oldContent;
+		returnPostData.newContent = oldContent;
+
+		await topics.notifyFollowers(returnPostData, data.uid, {
+			type: 'post-edit',
+			bodyShort: translator.compile('notifications:user-edited-post', editor.username, topic.title),
+			nid: `edit_post:${data.pid}:uid:${data.uid}`,
+		});
+		await topics.syncBacklinks(returnPostData);
+
+		plugins.hooks.fire('action:post.edit', { post: _.clone(returnPostData), data: data, uid: data.uid, answered: answered });
+
+		require('./cache').del(String(postData.pid));
+		pubsub.publish('post:edit', String(postData.pid));
+
+		await Posts.parsePost(returnPostData);
+
+		return {
+			topic: topic,
+			editor: editor,
+			post: returnPostData,
+			answered: answered,
+		};
+	};
+
 	async function editMainPost(data, postData, topicData) {
 		const { tid } = postData;
 		const title = data.title ? data.title.trim() : '';

--- a/src/posts/index.js
+++ b/src/posts/index.js
@@ -61,6 +61,14 @@ Posts.getUrgentPosts = async function (uid) {
 		.toSorted((a, b) => parseInt(a.urg_id, 10) - parseInt(b.urg_id, 10));
 };
 
+Posts.getUnansweredUrgentPosts = async function (uid) {
+	const pids = await db.getSortedSetRevRange('posts:pid', 0, 100);
+	const posts = await Posts.getPostsByPids(pids, uid);
+	return posts
+		.filter(post => parseInt(post.urg_id, 10) > 1 && !post.answered)
+		.toSorted((a, b) => parseInt(a.urg_id, 10) - parseInt(b.urg_id, 10));
+};
+
 Posts.getPostSummariesFromSet = async function (set, uid, start, stop) {
 	let pids = await db.getSortedSetRevRange(set, start, stop);
 	pids = await privileges.posts.filter('topics:read', pids, uid);

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -15,7 +15,10 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:pid', [middleware.ensureLoggedIn, middleware.checkRequired.bind(null, ['content'])], controllers.write.posts.edit);
 	setupApiRoute(router, 'delete', '/:pid', middlewares, controllers.write.posts.purge);
 
+	setupApiRoute(router, 'put', '/:pid/answered', middlewares, controllers.write.posts.editAnswered);
+
 	setupApiRoute(router, 'get', '/:uid/urgency', [], controllers.write.posts.getUrgentPosts);
+	setupApiRoute(router, 'get', '/:uid/unanswered', [], controllers.write.posts.getUnansweredUrgentPosts);
 
 	setupApiRoute(router, 'get', '/:pid/index', [middleware.assert.post], controllers.write.posts.getIndex);
 	setupApiRoute(router, 'get', '/:pid/raw', [middleware.assert.post], controllers.write.posts.getRaw);


### PR DESCRIPTION
## Qué?
Se implementó una busqueda en la Base de Datos donde mediante el ID del usuario, busca todos los posts con urgencia que no han sido contestados.
## Por qué?
Esta implementación permite tener un mejor control y visibilidad sobre cuáles posts han sido respondidos y cuáles aún requieren atención, mejorando así la gestión y seguimiento de las interacciones en la plataforma.
## Cómo?
Se agregó una ruta `:uid/unanswered`, en donde se filtran los posts en base a si tienen una urgencia y si no han sido contestados por el profesor. Asi mismo, se habilito una forma de editar el post segun el id del mismo para cambiar el estado de respuesta.
## Issues Relacionados
#24 #30 